### PR TITLE
build: Add ability to use preinstalled vendor.img

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -2152,8 +2152,10 @@ vendorimage-nodeps vnod: | $(INTERNAL_USERIMAGES_DEPS) $(DEPMOD)
 sync: $(INTERNAL_VENDORIMAGE_FILES)
 
 else ifdef BOARD_PREBUILT_VENDORIMAGE
+ifneq (true,$(BOARD_PREBUILT_VENDORIMAGE))
 INSTALLED_VENDORIMAGE_TARGET := $(PRODUCT_OUT)/vendor.img
 $(eval $(call copy-one-file,$(BOARD_PREBUILT_VENDORIMAGE),$(INSTALLED_VENDORIMAGE_TARGET)))
+endif
 endif
 
 # -----------------------------------------------------------------
@@ -2956,8 +2958,12 @@ ifdef BOARD_PREBUILT_VBMETAIMAGE
 	$(hide) cp $(INSTALLED_VBMETAIMAGE_TARGET) $(zip_root)/IMAGES/
 endif
 ifdef BOARD_PREBUILT_VENDORIMAGE
+ifeq (true,$(BOARD_PREBUILT_VENDORIMAGE))
+	$(hide) echo "vendor_prebuilt_installed=true" >> $(zip_root)/META/misc_info.txt
+else
 	$(hide) mkdir -p $(zip_root)/IMAGES
 	$(hide) cp $(INSTALLED_VENDORIMAGE_TARGET) $(zip_root)/IMAGES/
+endif
 endif
 ifdef BOARD_PREBUILT_PRODUCTIMAGE
 	$(hide) mkdir -p $(zip_root)/IMAGES

--- a/tools/releasetools/add_img_to_target_files.py
+++ b/tools/releasetools/add_img_to_target_files.py
@@ -669,9 +669,10 @@ def AddImagesToTargetFiles(filename):
   # could be built from source, or dropped into target_files.zip as a prebuilt
   # blob. We consider either of them as {vendor,product}.img being available,
   # which could be used when generating vbmeta.img for AVB.
-  has_vendor = (os.path.isdir(os.path.join(OPTIONS.input_tmp, "VENDOR")) or
+  has_vendor = ((os.path.isdir(os.path.join(OPTIONS.input_tmp, "VENDOR")) or
                 os.path.exists(os.path.join(OPTIONS.input_tmp, "IMAGES",
-                                            "vendor.img")))
+                                            "vendor.img"))) and
+                OPTIONS.info_dict.get("vendor_prebuilt_installed") != "true")
   has_product = (os.path.isdir(os.path.join(OPTIONS.input_tmp, "PRODUCT")) or
                  os.path.exists(os.path.join(OPTIONS.input_tmp, "IMAGES",
                                              "product.img")))


### PR DESCRIPTION
* On Pixel devices our vendor.img is preinstalled, we don't want to overwrite that

Change-Id: I916b26d7afd21d4b3cdae1a33a529ede68e55f3a